### PR TITLE
Make file paths relative to repo

### DIFF
--- a/configs/ocr.yaml
+++ b/configs/ocr.yaml
@@ -2,13 +2,13 @@ model:
   input_channels: 1
   rnn_hidden_size: 512
   num_rnn_layers: 2
-  char_list_path: /Users/paarthmiglani/PycharmProjects/testingagent/data/char_list.txt
+  char_list_path: data/char_list.txt
 training:
-  dataset_path: /Users/paarthmiglani/PycharmProjects/manualagent/images
-  annotations_file: /Users/paarthmiglani/PycharmProjects/testingagent/data/train_annotations.csv
-  validation_dataset_path: /Users/paarthmiglani/PycharmProjects/manualagent/validation_images
-  validation_annotations_file: /Users/paarthmiglani/PycharmProjects/testingagent/data/val_annotations.csv
-  char_list_path: /Users/paarthmiglani/PycharmProjects/testingagent/data/char_list.txt
+  dataset_path: data/images
+  annotations_file: data/train_annotations.csv
+  validation_dataset_path: data/validation_images
+  validation_annotations_file: data/val_annotations.csv
+  char_list_path: data/char_list.txt
   batch_size: 32
   epochs: 10
   learning_rate: 0.001

--- a/configs/ocr_crops.yaml
+++ b/configs/ocr_crops.yaml
@@ -2,14 +2,14 @@ model:
   input_channels: 1
   rnn_hidden_size: 1024
   num_rnn_layers: 2
-  char_list_path: /Users/paarthmiglani/PycharmProjects/testingagent/data/char_list.txt
+  char_list_path: data/char_list.txt
 
 training:
-  dataset_path: /Users/paarthmiglani/PycharmProjects/manualagent/ocr_crops                  # Train image crops
-  annotations_file: /Users/paarthmiglani/PycharmProjects/testingagent/data/crop_annotations.csv   # Train crops CSV
-  validation_dataset_path: /Users/paarthmiglani/PycharmProjects/manualagent/ocr_crops_val        # Validation image crops (same dir, different CSV)
-  validation_annotations_file: /Users/paarthmiglani/PycharmProjects/testingagent/data/crop_annotations_val.csv # Validation crops CSV
-  char_list_path: /Users/paarthmiglani/PycharmProjects/testingagent/data/char_list.txt
+  dataset_path: data/ocr_crops                  # Train image crops
+  annotations_file: data/crop_annotations.csv   # Train crops CSV
+  validation_dataset_path: data/ocr_crops_val        # Validation image crops (same dir, different CSV)
+  validation_annotations_file: data/crop_annotations_val.csv # Validation crops CSV
+  char_list_path: data/char_list.txt
   batch_size: 16
   epochs: 100
   learning_rate: 0.01

--- a/configs/yolo_data.yaml
+++ b/configs/yolo_data.yaml
@@ -1,4 +1,4 @@
-train: /Users/paarthmiglani/PycharmProjects/manualagent/images
-val: /Users/paarthmiglani/PycharmProjects/manualagent/yolo/images
+train: data/images
+val: data/yolo/images
 nc: 1
 names: ["text"]

--- a/src/nlp/agent.py
+++ b/src/nlp/agent.py
@@ -28,7 +28,9 @@ class IndicCulturalChatAgent:
 
 # Example usage
 if __name__ == "__main__":
-    translit_dir = "/Users/paarthmiglani/PycharmProjects/testingagent/data/nlpdata"
+    from pathlib import Path
+    BASE_DIR = Path(__file__).resolve().parents[2]
+    translit_dir = BASE_DIR / "data" / "nlpdata"
     knowledge_dir = translit_dir
     agent = IndicCulturalChatAgent(translit_dir, knowledge_dir)
     print(agent.handle_input("धर्म"))

--- a/src/ocr/create_crops_for_validation.py
+++ b/src/ocr/create_crops_for_validation.py
@@ -3,11 +3,14 @@ import cv2
 import csv
 
 # --- UPDATE THESE FOR VALIDATION SPLIT ---
-images_dir = "/Users/paarthmiglani/PycharmProjects/manualagent/validation_images"
-labels_dir = "/Users/paarthmiglani/PycharmProjects/manualagent/validation_labels"
-source_anno_csv = "/Users/paarthmiglani/PycharmProjects/testingagent/data/val_annotations.csv"
-crops_dir = "/Users/paarthmiglani/PycharmProjects/manualagent/ocr_crops_val"
-ANNOT_OUT = "/Users/paarthmiglani/PycharmProjects/testingagent/data/crop_annotations_val.csv"
+from pathlib import Path
+BASE_DIR = Path(__file__).resolve().parents[2]
+
+images_dir = BASE_DIR / "data" / "validation_images"
+labels_dir = BASE_DIR / "data" / "validation_labels"
+source_anno_csv = BASE_DIR / "data" / "val_annotations.csv"
+crops_dir = BASE_DIR / "data" / "ocr_crops_val"
+ANNOT_OUT = BASE_DIR / "data" / "crop_annotations_val.csv"
 
 os.makedirs(crops_dir, exist_ok=True)
 

--- a/src/ocr/create_ocr_crops_from_yolo.py
+++ b/src/ocr/create_ocr_crops_from_yolo.py
@@ -3,11 +3,14 @@ import cv2
 import csv
 
 # Paths to your folders
-images_dir = "/Users/paarthmiglani/PycharmProjects/manualagent/images"
-labels_dir = "/Users/paarthmiglani/PycharmProjects/manualagent/labels"
-source_anno_csv = "/Users/paarthmiglani/PycharmProjects/testingagent/data/train_annotations.csv"
-crops_dir = "/Users/paarthmiglani/PycharmProjects/manualagent/ocr_crops"
-ANNOT_OUT = "/Users/paarthmiglani/PycharmProjects/testingagent/data/crop_annotations.csv"
+from pathlib import Path
+BASE_DIR = Path(__file__).resolve().parents[2]
+
+images_dir = BASE_DIR / "data" / "images"
+labels_dir = BASE_DIR / "data" / "labels"
+source_anno_csv = BASE_DIR / "data" / "train_annotations.csv"
+crops_dir = BASE_DIR / "data" / "ocr_crops"
+ANNOT_OUT = BASE_DIR / "data" / "crop_annotations.csv"
 
 os.makedirs(crops_dir, exist_ok=True)
 

--- a/src/ocr/yoloformattext.py
+++ b/src/ocr/yoloformattext.py
@@ -15,9 +15,12 @@ def quad_to_yolo_bbox(coords, img_w, img_h):
     return x_c, y_c, w, h
 
 # ---- CHANGE THESE -----
-IMAGES_DIR = "/Users/paarthmiglani/PycharmProjects/manualagent/images"
-LABELS_IN_DIR = "/Users/paarthmiglani/PycharmProjects/manualagent/imagestext"
-LABELS_OUT_DIR = "/Users/paarthmiglani/PycharmProjects/manualagent/labels"
+from pathlib import Path
+BASE_DIR = Path(__file__).resolve().parents[2]
+
+IMAGES_DIR = BASE_DIR / "data" / "images"
+LABELS_IN_DIR = BASE_DIR / "data" / "imagestext"
+LABELS_OUT_DIR = BASE_DIR / "data" / "labels"
 os.makedirs(LABELS_OUT_DIR, exist_ok=True)
 
 from PIL import Image

--- a/src/ocr/yoloformatvalidation.py
+++ b/src/ocr/yoloformatvalidation.py
@@ -2,9 +2,12 @@ import os
 import glob
 
 # Define paths
-IMAGE_DIR = "/Users/paarthmiglani/PycharmProjects/manualagent/yolo/images"
-GT_DIR = "/Users/paarthmiglani/PycharmProjects/manualagent/yolo/text"
-OUT_LABEL_DIR = "/Users/paarthmiglani/PycharmProjects/manualagent/yolo/labels"
+from pathlib import Path
+BASE_DIR = Path(__file__).resolve().parents[2]
+
+IMAGE_DIR = BASE_DIR / "data" / "yolo" / "images"
+GT_DIR = BASE_DIR / "data" / "yolo" / "text"
+OUT_LABEL_DIR = BASE_DIR / "data" / "yolo" / "labels"
 
 os.makedirs(OUT_LABEL_DIR, exist_ok=True)
 

--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -5,15 +5,18 @@ from src.nlp.agent import IndicCulturalChatAgent
 from src.ocr.easyocr_infer import run_easyocr_on_image
 
 # --- AGENT SETUP (adjust paths as needed) ---
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parents[1]
 translit_paths = {
-    "hi": "/Users/paarthmiglani/PycharmProjects/testingagent/data/hindi_transliterated.csv",
-    "te": "/Users/paarthmiglani/PycharmProjects/testingagent/data/telugu_books.csv",
+    "hi": str(BASE_DIR / "data" / "hindi_transliterated.csv"),
+    "te": str(BASE_DIR / "data" / "telugu_books.csv"),
     # add more if needed
 }
 knowledge_files = {
-    "mahabharat": "/Users/paarthmiglani/PycharmProjects/testingagent/data/Mahabharat.csv",
-    "gita": "/Users/paarthmiglani/PycharmProjects/testingagent/data/MERGED_GITA_MANTRAS.csv",
-    "upanishads": "/Users/paarthmiglani/PycharmProjects/testingagent/data/MERGED_upanishads.csv",
+    "mahabharat": str(BASE_DIR / "data" / "Mahabharat.csv"),
+    "gita": str(BASE_DIR / "data" / "MERGED_GITA_MANTRAS.csv"),
+    "upanishads": str(BASE_DIR / "data" / "MERGED_upanishads.csv"),
     # ... add more
 }
 agent = IndicCulturalChatAgent(translit_paths, knowledge_files)


### PR DESCRIPTION
## Summary
- use repo-relative paths in NLP agent example and Streamlit app
- update dataset path constants in OCR utilities
- clean up config files to avoid absolute paths

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a7ac289cc83218d47a0fad697022d