### PR TITLE
Fix keyword search error handling

### DIFF
--- a/src/nlp/search.py
+++ b/src/nlp/search.py
@@ -13,6 +13,9 @@ def keyword_search(query, dataset_path):
         except Exception as e:
             print(f"Failed to read {dataset_path}: {e}")
             return pd.DataFrame()  # Return empty if all fail
+    except FileNotFoundError:
+        print(f"File not found: {dataset_path}")
+        return pd.DataFrame()
     # Now do search
     results = df[df.apply(lambda row: query.lower() in str(row).lower(), axis=1)]
     return results


### PR DESCRIPTION
## Summary
- handle missing dataset files in `keyword_search`
- add newline at end of file

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687a7a8a3d0483219430e0f0964e8fe0